### PR TITLE
Fix warning if squire is used without namespaces

### DIFF
--- a/lib/squire/configuration.rb
+++ b/lib/squire/configuration.rb
@@ -49,7 +49,7 @@ module Squire
     def settings(&block)
       @settings ||= setup
 
-      settings = @namespace ? @settings.get_value(@namespace) : @settings
+      settings = defined?(@namespace) ? @settings.get_value(@namespace) : @settings
 
       if block_given?
         block.arity == 0 ? settings.instance_eval(&block) : block.call(settings)

--- a/lib/squire/configuration.rb
+++ b/lib/squire/configuration.rb
@@ -49,7 +49,7 @@ module Squire
     def settings(&block)
       @settings ||= setup
 
-      settings = defined?(@namespace) ? @settings.get_value(@namespace) : @settings
+      settings = instance_variable_defined?(:@namespace) ? @settings.get_value(@namespace) : @settings
 
       if block_given?
         block.arity == 0 ? settings.instance_eval(&block) : block.call(settings)


### PR DESCRIPTION
Fix the warning reported in github issue #2
